### PR TITLE
Remove OCR from PDF extraction

### DIFF
--- a/app3.py
+++ b/app3.py
@@ -76,8 +76,6 @@ client = create_openai_wrapper(api_key)
 
 # --- セッション初期化 ----------------------------------------------
 BASE_DIR = Path(getattr(sys, "_MEIPASS", Path(__file__).resolve().parent))
-POPPLER_DIR = BASE_DIR / "poppler" / "bin"
-TESSERACT_EXE = BASE_DIR / "tesseract" / "tesseract.exe"
 
 GREETING = "質問してみましょう"
 if "messages" not in st.session_state:
@@ -144,17 +142,6 @@ else:
         except Exception as e:
             logging.warning("PyMuPDF 失敗: %s", e)
 
-        # 4) OCR – Poppler + Tesseract
-        try:
-            from pdf2image import convert_from_bytes
-            import pytesseract
-            pages = convert_from_bytes(data, dpi=300, fmt="png", poppler_path=str(POPPLER_DIR))
-            pytesseract.pytesseract.tesseract_cmd = str(TESSERACT_EXE)
-            ocr_text = "\n".join(pytesseract.image_to_string(p, lang="jpn") for p in pages)
-            if ocr_text.strip():
-                return ocr_text[:180_000]
-        except Exception as e:
-            logging.warning("OCR 失敗: %s", e)
 
         return "(PDF からテキストを抽出できませんでした)"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,4 @@ pdfminer.six
 PyPDF2
 PyMuPDF
 pdfplumber
-#pdf2image
-#pytesseract
 Pillow


### PR DESCRIPTION
## Summary
- drop Poppler/Tesseract paths
- remove OCR step from PDF text extraction
- clean up requirements

## Testing
- `python -m py_compile app3.py`