### PR TITLE
Fix file encoding detection for Japanese attachments

### DIFF
--- a/app3.py
+++ b/app3.py
@@ -96,10 +96,21 @@ if uploaded_file and uploaded_file.name.endswith(".PDF"):
 else:
     def read_text_file(file):
         raw = file.read()
-        for enc in ("utf-8", "cp932"):
+        encodings = (
+            "utf-8",
+            "utf-8-sig",
+            "cp932",
+            "shift_jis",
+            "euc-jp",
+            "iso2022_jp",
+            "utf-16",
+            "utf-16-le",
+            "utf-16-be",
+        )
+        for enc in encodings:
             try:
-                return raw.decode(enc, errors="ignore")[:180_000]
-            except UnicodeDecodeError:
+                return raw.decode(enc)[:180_000]
+            except Exception:
                 continue
         return raw.decode(errors="ignore")[:180_000]
 


### PR DESCRIPTION
## Summary
- improve the `read_text_file` helper to try more encodings including UTF‑8 with BOM, Shift_JIS and UTF‑16 variants

## Testing
- `git status --short`