### PR TITLE
Improve file decoding for Japanese text

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ PyPDF2
 PyMuPDF
 pdfplumber
 Pillow
+chardet


### PR DESCRIPTION
## Summary
- use `chardet` to guess encoding when reading uploaded text files
- add `chardet` dependency

## Testing
- `pip install -q -r requirements.txt` *(fails: Could not find a version that satisfies the requirement streamlit)*
- `git status --short`